### PR TITLE
Add DeviantArt artist browse CTA support

### DIFF
--- a/app/Http/Controllers/ExtensionApiController.php
+++ b/app/Http/Controllers/ExtensionApiController.php
@@ -7,6 +7,7 @@ use App\Models\Reaction;
 use App\Services\Extension\ExtensionApiPayloadSupport;
 use App\Services\Extension\ExtensionCivitAiBrowseTabService;
 use App\Services\Extension\ExtensionContainerMetadataService;
+use App\Services\Extension\ExtensionDeviantArtBrowseTabService;
 use App\Services\Extension\ExtensionDownloadRuntimeContext;
 use App\Services\Extension\ExtensionListingMetadataOverridesNormalizer;
 use App\Services\Extension\ExtensionMediaMatchService;
@@ -462,6 +463,26 @@ class ExtensionApiController extends Controller
 
         return response()->json(
             app(ExtensionCivitAiBrowseTabService::class)->openUserTab($user, $validated)
+        );
+    }
+
+    public function openDeviantArtUserBrowseTab(
+        Request $request,
+        ExtensionApiKeyService $extensionApiKey,
+    ): JsonResponse {
+        $user = $this->extensionAuthenticator->resolveUser($request, $extensionApiKey);
+        if (! $user) {
+            return response()->json([
+                'message' => 'Invalid extension API key.',
+            ], 401);
+        }
+
+        $validated = $request->validate([
+            'username' => ['required', 'string', 'max:255'],
+        ]);
+
+        return response()->json(
+            app(ExtensionDeviantArtBrowseTabService::class)->openUserTab($user, $validated)
         );
     }
 }

--- a/app/Services/Extension/ExtensionDeviantArtBrowseTabService.php
+++ b/app/Services/Extension/ExtensionDeviantArtBrowseTabService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Services\Extension;
+
+use App\Models\Tab;
+use App\Models\User;
+use App\Services\DeviantArtImages;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class ExtensionDeviantArtBrowseTabService
+{
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    public function openUserTab(User $user, array $validated): array
+    {
+        $username = trim((string) $validated['username']);
+        if ($username === '' || ! $this->isValidUsername($username)) {
+            throw ValidationException::withMessages([
+                'username' => 'The username field must be a valid DeviantArt username.',
+            ]);
+        }
+
+        return $this->tabPayload($this->create(
+            $user,
+            "DeviantArt Images: User $username - 1",
+            [
+                'feed' => 'online',
+                'service' => DeviantArtImages::key(),
+                'page' => 1,
+                'limit' => 20,
+                'username' => $username,
+            ],
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    private function create(User $user, string $label, array $params): Tab
+    {
+        return DB::transaction(function () use ($user, $label, $params) {
+            $userId = (int) $user->id;
+            $nextPosition = (Tab::forUser($userId)->max('position') ?? -1) + 1;
+
+            Tab::forUser($userId)->update(['is_active' => false]);
+
+            return Tab::query()->create([
+                'user_id' => $userId,
+                'label' => $label,
+                'custom_label' => null,
+                'params' => $params,
+                'position' => $nextPosition,
+                'is_active' => true,
+            ]);
+        });
+    }
+
+    private function isValidUsername(string $value): bool
+    {
+        $normalized = strtolower(trim($value));
+        if ($normalized === '') {
+            return false;
+        }
+
+        if (in_array($normalized, [
+            'about',
+            'art',
+            'browse',
+            'daily-deviations',
+            'gallery',
+            'morelikethis',
+            'notifications',
+            'prints',
+            'search',
+            'settings',
+            'shop',
+            'watch',
+        ], true)) {
+            return false;
+        }
+
+        return preg_match('/^[a-z0-9_-]+$/i', $value) === 1;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function tabPayload(Tab $tab): array
+    {
+        return [
+            'tab' => [
+                'id' => $tab->id,
+                'label' => $tab->label,
+                'params' => $tab->params ?? [],
+            ],
+            'browse_url' => url('/browse'),
+        ];
+    }
+}

--- a/extension/src/background-deviantart-browse-tabs.test.ts
+++ b/extension/src/background-deviantart-browse-tabs.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetStoredOptions = vi.fn();
+
+vi.mock('./atlas-options', () => ({
+    getStoredOptions: mockGetStoredOptions,
+}));
+
+function createChromeMock() {
+    return {
+        runtime: {
+            lastError: null,
+        },
+        tabs: {
+            create: vi.fn((_: { url?: string }, callback?: () => void) => {
+                callback?.();
+            }),
+        },
+    };
+}
+
+describe('handleOpenDeviantArtUsernameTabRuntimeMessage', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        mockGetStoredOptions.mockResolvedValue({
+            atlasDomain: 'https://atlas.test',
+            apiToken: 'test-api-token',
+        });
+    });
+
+    it('creates a new Atlas browser tab for a DeviantArt username browse request', async () => {
+        const chromeMock = createChromeMock();
+        const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+            browse_url: 'https://atlas.test/browse',
+            tab: {
+                id: 48,
+                label: 'DeviantArt Images: User velvetemberartist - 1',
+            },
+        }), { status: 200 }));
+        vi.stubGlobal('chrome', chromeMock);
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { handleOpenDeviantArtUsernameTabRuntimeMessage } = await import('./background-deviantart-browse-tabs');
+
+        const response = await new Promise((resolve) => {
+            const handled = handleOpenDeviantArtUsernameTabRuntimeMessage({
+                type: 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB',
+                username: 'velvetemberartist',
+            }, resolve);
+
+            expect(handled).toBe(true);
+        });
+
+        expect(mockGetStoredOptions).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('https://atlas.test/api/extension/browse-tabs/deviantart-user', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Atlas-Api-Key': 'test-api-token',
+            },
+            body: JSON.stringify({
+                username: 'velvetemberartist',
+            }),
+        });
+        expect(chromeMock.tabs.create).toHaveBeenCalledWith({ url: 'https://atlas.test/browse' }, expect.any(Function));
+        expect(response).toEqual({
+            ok: true,
+            status: 200,
+            payload: {
+                browse_url: 'https://atlas.test/browse',
+                tab: {
+                    id: 48,
+                    label: 'DeviantArt Images: User velvetemberartist - 1',
+                },
+            },
+        });
+    });
+});

--- a/extension/src/background-deviantart-browse-tabs.ts
+++ b/extension/src/background-deviantart-browse-tabs.ts
@@ -1,0 +1,112 @@
+import { getStoredOptions } from './atlas-options';
+import { createAtlasApiHeaders, createAtlasFetchAuthOptions, hasAtlasApiAuth, normalizeAtlasDomain } from './atlas-auth';
+
+type RuntimeSendResponse = (response?: unknown) => void;
+
+type OpenDeviantArtUsernameTabPayload = {
+    type: 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB';
+    username: unknown;
+};
+
+function parseJsonResponse(response: Response): Promise<unknown> {
+    return response.text()
+        .then((bodyText) => {
+            const trimmed = bodyText.trim();
+            if (trimmed === '') {
+                return null;
+            }
+
+            try {
+                return JSON.parse(trimmed) as unknown;
+            } catch {
+                return bodyText;
+            }
+        })
+        .catch(() => null);
+}
+
+function parseNonEmptyString(value: unknown, maxLength: number): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed !== '' && trimmed.length <= maxLength ? trimmed : null;
+}
+
+function resolveBrowseUrlFromPayload(payload: unknown): string | null {
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+
+    const browseUrl = (payload as Record<string, unknown>).browse_url;
+
+    return typeof browseUrl === 'string' && browseUrl.trim() !== '' ? browseUrl.trim() : null;
+}
+
+async function openDeviantArtBrowseTab(
+    endpoint: string,
+    body: Record<string, unknown>,
+    sendResponse: RuntimeSendResponse,
+): Promise<void> {
+    const stored = await getStoredOptions();
+    const atlasDomain = normalizeAtlasDomain(stored.atlasDomain);
+    const apiToken = stored.apiToken.trim();
+    if (atlasDomain === '' || !hasAtlasApiAuth(atlasDomain, apiToken)) {
+        sendResponse({ ok: false, status: 0, payload: null });
+        return;
+    }
+
+    const response = await fetch(`${atlasDomain}/api/extension/browse-tabs/${endpoint}`, {
+        method: 'POST',
+        headers: createAtlasApiHeaders(apiToken, true),
+        ...createAtlasFetchAuthOptions(apiToken),
+        body: JSON.stringify(body),
+    });
+    const responsePayload = await parseJsonResponse(response);
+    const browseUrl = resolveBrowseUrlFromPayload(responsePayload);
+
+    if (!response.ok || browseUrl === null) {
+        sendResponse({
+            ok: false,
+            status: response.status,
+            payload: responsePayload,
+        });
+        return;
+    }
+
+    chrome.tabs.create({ url: browseUrl }, () => {
+        sendResponse({
+            ok: !chrome.runtime.lastError,
+            status: response.status,
+            payload: responsePayload,
+        });
+    });
+}
+
+export function handleOpenDeviantArtUsernameTabRuntimeMessage(
+    message: unknown,
+    sendResponse: RuntimeSendResponse,
+): boolean {
+    if (!message || typeof message !== 'object') {
+        return false;
+    }
+
+    const payload = message as OpenDeviantArtUsernameTabPayload;
+    if (payload.type !== 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB') {
+        return false;
+    }
+
+    const username = parseNonEmptyString(payload.username, 255);
+    if (username === null) {
+        sendResponse({ ok: false, status: 0, payload: null });
+        return false;
+    }
+
+    void openDeviantArtBrowseTab('deviantart-user', { username }, sendResponse).catch(() => {
+        sendResponse({ ok: false, status: 0, payload: null });
+    });
+
+    return true;
+}

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -14,6 +14,7 @@ import {
     handleOpenCivitAiModelTabRuntimeMessage,
     handleOpenCivitAiUsernameTabRuntimeMessage,
 } from './background-civitai-browse-tabs';
+import { handleOpenDeviantArtUsernameTabRuntimeMessage } from './background-deviantart-browse-tabs';
 import { isHttpTabUrl } from './background-url-utils';
 import { normalizeComparableOpenTabUrl } from './open-tab-url';
 import { resolveTabDomainGroupKey, summarizeTabCounts } from './tab-counts';
@@ -323,7 +324,8 @@ chrome.runtime.onMessage.addListener((
         || handleQueuedReferrerCheckRuntimeMessage(message, sender, sendResponse)
         || handleAtlasApiRequestRuntimeMessage(message, sendResponse)
         || handleOpenCivitAiModelTabRuntimeMessage(message, sender, sendResponse)
-        || handleOpenCivitAiUsernameTabRuntimeMessage(message, sender, sendResponse)) {
+        || handleOpenCivitAiUsernameTabRuntimeMessage(message, sender, sendResponse)
+        || handleOpenDeviantArtUsernameTabRuntimeMessage(message, sendResponse)) {
         return true;
     }
 

--- a/extension/src/content-main.ts
+++ b/extension/src/content-main.ts
@@ -23,6 +23,7 @@ import { createDuplicateAnchorTabGuard } from './content/duplicate-anchor-tab-gu
 import { clearDeviantArtBackgroundImageStyle } from './content/deviantart-background-image-style';
 import { installCivitAiModelBrowseCtas } from './content/civitai-model-browse-cta';
 import { installCivitAiUserBrowseLinks } from './content/civitai-user-browse-link';
+import { installDeviantArtArtistBrowseCtas } from './content/deviantart-artist-browse-cta';
 import { installPageVisibilityLifecycle, isPageVisible } from './content/page-work-lifecycle';
 import { shouldBypassBadgeCheckCacheForPageStart } from './content/restored-page-badge-check';
 import { isVisibleInViewport } from './content/viewport-visibility';
@@ -479,6 +480,7 @@ function installPageEnhancements(): void {
     const cleanups = [
         installCivitAiModelBrowseCtas(),
         installCivitAiUserBrowseLinks(),
+        installDeviantArtArtistBrowseCtas(),
     ].filter((cleanup): cleanup is () => void => typeof cleanup === 'function');
     pageEnhancementCleanups.push(...cleanups);
 }

--- a/extension/src/content/deviantart-artist-browse-cta.test.ts
+++ b/extension/src/content/deviantart-artist-browse-cta.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function flushPromises(): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+}
+
+describe('installDeviantArtArtistBrowseCtas', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        vi.unstubAllGlobals();
+        document.body.innerHTML = '';
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: new URL('https://www.deviantart.com/') as unknown as Location,
+        });
+        vi.stubGlobal('MutationObserver', class {
+            disconnect(): void {}
+            observe(): void {}
+        });
+
+        vi.stubGlobal('chrome', {
+            runtime: {
+                lastError: null,
+                sendMessage: vi.fn((_: unknown, callback?: (response: unknown) => void) => {
+                    callback?.({ ok: true });
+                }),
+            },
+        });
+    });
+
+    it('adds an Atlas CTA beside the DeviantArt profile header username', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: new URL('https://www.deviantart.com/velvetemberartist') as unknown as Location,
+        });
+        document.body.innerHTML = `
+            <h1 class="xFFJW8">
+                <a class="user-link PX4oKN NYgYcG" href="https://www.deviantart.com/velvetemberartist">
+                    VelvetEmberArtist
+                </a>
+            </h1>
+        `;
+
+        const { installDeviantArtArtistBrowseCtas } = await import('./deviantart-artist-browse-cta');
+
+        installDeviantArtArtistBrowseCtas();
+
+        const button = document.querySelector('[data-atlas-deviantart-artist-browse-cta]');
+
+        expect(button).toBeInstanceOf(HTMLButtonElement);
+        expect(button?.textContent).toBe('Open in Atlas');
+        expect(button?.previousElementSibling?.textContent?.trim()).toBe('VelvetEmberArtist');
+
+        button?.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        }));
+        await flushPromises();
+
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+            type: 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB',
+            username: 'velvetemberartist',
+            sourceHostname: 'www.deviantart.com',
+            sourceUrl: 'https://www.deviantart.com/velvetemberartist',
+        }, expect.any(Function));
+    });
+
+    it('adds the CTA beside the deviation byline username without targeting More by links', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: new URL('https://www.deviantart.com/velvetemberartist/art/Exclusive-Artwork-Adoptable-1339260729') as unknown as Location,
+        });
+        document.body.innerHTML = `
+            <aside>
+                <a class="user-link PX4oKN wl3JTQ" href="https://www.deviantart.com/velvetemberartist/gallery?deviationid=1339260729#content">
+                    More by VelvetEmberArtist
+                </a>
+            </aside>
+            <section>
+                <div class="g4q3kb">
+                    <span>By</span>
+                    <div class="TzdmPT kmjYyN">
+                        <a class="user-link PX4oKN" href="https://www.deviantart.com/velvetemberartist/gallery">
+                            VelvetEmberArtist
+                        </a>
+                    </div>
+                    <button type="button">Watch</button>
+                </div>
+            </section>
+        `;
+
+        const { installDeviantArtArtistBrowseCtas } = await import('./deviantart-artist-browse-cta');
+
+        installDeviantArtArtistBrowseCtas();
+
+        const buttons = Array.from(document.querySelectorAll('[data-atlas-deviantart-artist-browse-cta]'));
+
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0]?.previousElementSibling?.textContent?.trim()).toBe('VelvetEmberArtist');
+
+        buttons[0]?.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        }));
+        await flushPromises();
+
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+            type: 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB',
+            username: 'velvetemberartist',
+            sourceHostname: 'www.deviantart.com',
+            sourceUrl: 'https://www.deviantart.com/velvetemberartist/art/Exclusive-Artwork-Adoptable-1339260729',
+        }, expect.any(Function));
+    });
+
+    it('does nothing outside DeviantArt pages', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: new URL('https://example.com/velvetemberartist') as unknown as Location,
+        });
+        document.body.innerHTML = `
+            <h1>
+                <a href="https://www.deviantart.com/velvetemberartist">VelvetEmberArtist</a>
+            </h1>
+        `;
+
+        const { installDeviantArtArtistBrowseCtas } = await import('./deviantart-artist-browse-cta');
+
+        installDeviantArtArtistBrowseCtas();
+
+        expect(document.querySelector('[data-atlas-deviantart-artist-browse-cta]')).toBeNull();
+    });
+});

--- a/extension/src/content/deviantart-artist-browse-cta.ts
+++ b/extension/src/content/deviantart-artist-browse-cta.ts
@@ -1,0 +1,322 @@
+const CTA_TEXT = 'Open in Atlas';
+const CTA_PENDING_TEXT = 'Opening...';
+const CTA_SUCCESS_TEXT = 'Opened';
+const CTA_FAILURE_TEXT = 'Failed';
+const CTA_SELECTOR = '[data-atlas-deviantart-artist-browse-cta]';
+const noop = (): void => {};
+
+type DeviantArtUsernameReference = {
+    username: string;
+    key: string;
+};
+
+type RuntimeOpenResponse = {
+    ok?: boolean;
+};
+
+let isInstalled = false;
+
+function isDeviantArtHostname(hostname: string = window.location.hostname): boolean {
+    const normalized = hostname.toLowerCase().trim();
+
+    return normalized === 'deviantart.com' || normalized.endsWith('.deviantart.com');
+}
+
+function isReservedPathSegment(value: string): boolean {
+    return [
+        'about',
+        'art',
+        'browse',
+        'daily-deviations',
+        'gallery',
+        'morelikethis',
+        'notifications',
+        'prints',
+        'search',
+        'settings',
+        'shop',
+        'watch',
+    ].includes(value.toLowerCase());
+}
+
+function parseUsernameSegment(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    let username: string;
+    try {
+        username = decodeURIComponent(value).trim();
+    } catch {
+        return null;
+    }
+
+    if (
+        username === ''
+        || username.length > 255
+        || isReservedPathSegment(username)
+        || /^[a-z0-9_-]+$/i.test(username) === false
+    ) {
+        return null;
+    }
+
+    return username;
+}
+
+function parseUsernameReferenceFromUrl(href: string = window.location.href): DeviantArtUsernameReference | null {
+    let url: URL;
+
+    try {
+        url = new URL(href, window.location.href);
+    } catch {
+        return null;
+    }
+
+    if (!isDeviantArtHostname(url.hostname)) {
+        return null;
+    }
+
+    const [rawUsername] = url.pathname.split('/').filter((segment) => segment !== '');
+    const username = parseUsernameSegment(rawUsername);
+    if (username === null) {
+        return null;
+    }
+
+    return {
+        username,
+        key: username.toLowerCase(),
+    };
+}
+
+function isDeviationPage(href: string = window.location.href): boolean {
+    try {
+        const url = new URL(href, window.location.href);
+        const segments = url.pathname.split('/').filter((segment) => segment !== '');
+
+        return segments[1] === 'art';
+    } catch {
+        return false;
+    }
+}
+
+function isProfileHeaderAnchor(anchor: HTMLAnchorElement): boolean {
+    return anchor.closest('h1') !== null;
+}
+
+function normalizeText(value: string | null | undefined): string {
+    return (value ?? '').trim().toLowerCase();
+}
+
+function normalizeCollapsedText(value: string | null | undefined): string {
+    return normalizeText(value).replace(/\s+/g, ' ');
+}
+
+function resolveAnchorUsername(anchor: HTMLAnchorElement): DeviantArtUsernameReference | null {
+    const href = anchor.getAttribute('href');
+
+    return href === null ? null : parseUsernameReferenceFromUrl(href);
+}
+
+function isDeviationBylineAnchor(anchor: HTMLAnchorElement, reference: DeviantArtUsernameReference): boolean {
+    let current = anchor.parentElement;
+    let depth = 0;
+
+    while (current instanceof HTMLElement && depth < 5) {
+        const text = normalizeCollapsedText(current.textContent);
+        if (text.startsWith(`by ${reference.key}`) || text.startsWith(`by${reference.key}`)) {
+            return true;
+        }
+
+        current = current.parentElement;
+        depth += 1;
+    }
+
+    return false;
+}
+
+function isCandidateArtistAnchor(anchor: HTMLAnchorElement, reference: DeviantArtUsernameReference): boolean {
+    const anchorReference = resolveAnchorUsername(anchor);
+    if (anchorReference === null || anchorReference.key !== reference.key) {
+        return false;
+    }
+
+    if (normalizeText(anchor.textContent) !== reference.key) {
+        return false;
+    }
+
+    if (isProfileHeaderAnchor(anchor)) {
+        return true;
+    }
+
+    return isDeviationPage() && isDeviationBylineAnchor(anchor, reference);
+}
+
+function setButtonState(
+    button: HTMLButtonElement,
+    label: string,
+    disabled: boolean,
+): void {
+    button.textContent = label;
+    button.disabled = disabled;
+    button.style.opacity = disabled ? '0.72' : '1';
+    button.style.cursor = disabled ? 'default' : 'pointer';
+}
+
+function requestOpenDeviantArtUsernameTab(reference: DeviantArtUsernameReference): Promise<RuntimeOpenResponse | null> {
+    if (typeof chrome === 'undefined' || !chrome.runtime || typeof chrome.runtime.sendMessage !== 'function') {
+        return Promise.resolve(null);
+    }
+
+    return new Promise((resolve) => {
+        try {
+            chrome.runtime.sendMessage({
+                type: 'ATLAS_OPEN_DEVIANTART_USERNAME_TAB',
+                username: reference.username,
+                sourceHostname: window.location.hostname,
+                sourceUrl: window.location.href,
+            }, (response: unknown) => {
+                if (chrome.runtime.lastError) {
+                    resolve(null);
+                    return;
+                }
+
+                resolve(response && typeof response === 'object' ? response as RuntimeOpenResponse : null);
+            });
+        } catch {
+            resolve(null);
+        }
+    });
+}
+
+function createCtaButton(reference: DeviantArtUsernameReference): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.atlasDeviantartArtistBrowseCta = reference.key;
+    button.title = 'Open this DeviantArt artist in Atlas';
+    button.style.cssText = [
+        'appearance:none',
+        'display:inline-flex',
+        'align-items:center',
+        'justify-content:center',
+        'min-height:24px',
+        'margin-left:8px',
+        'padding:4px 10px',
+        'border-radius:999px',
+        'border:1px solid rgba(34, 139, 230, 0.3)',
+        'background:rgba(34, 139, 230, 0.08)',
+        'color:#228be6',
+        'font-size:12px',
+        'font-weight:600',
+        'line-height:1.2',
+        'white-space:nowrap',
+        'vertical-align:middle',
+    ].join(';');
+    setButtonState(button, CTA_TEXT, false);
+
+    button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const currentReference = parseUsernameReferenceFromUrl() ?? reference;
+
+        setButtonState(button, CTA_PENDING_TEXT, true);
+
+        void requestOpenDeviantArtUsernameTab(currentReference)
+            .then((response) => {
+                setButtonState(button, response?.ok === true ? CTA_SUCCESS_TEXT : CTA_FAILURE_TEXT, true);
+            })
+            .catch(() => {
+                setButtonState(button, CTA_FAILURE_TEXT, true);
+            })
+            .finally(() => {
+                window.setTimeout(() => {
+                    if (button.isConnected) {
+                        setButtonState(button, CTA_TEXT, false);
+                    }
+                }, 1500);
+            });
+    });
+
+    return button;
+}
+
+function applyArtistBrowseCta(anchor: HTMLAnchorElement, reference: DeviantArtUsernameReference): void {
+    const existingButton = anchor.parentElement?.querySelector(CTA_SELECTOR);
+    if (existingButton instanceof HTMLButtonElement) {
+        if (existingButton.dataset.atlasDeviantartArtistBrowseCta === reference.key) {
+            return;
+        }
+
+        existingButton.remove();
+    }
+
+    anchor.insertAdjacentElement('afterend', createCtaButton(reference));
+}
+
+function syncArtistBrowseCtas(root: ParentNode): void {
+    const reference = parseUsernameReferenceFromUrl();
+    if (reference === null) {
+        return;
+    }
+
+    const directAnchors = root instanceof HTMLAnchorElement ? [root] : [];
+    for (const anchor of [...directAnchors, ...Array.from(root.querySelectorAll('a[href]'))]) {
+        if (!(anchor instanceof HTMLAnchorElement) || !isCandidateArtistAnchor(anchor, reference)) {
+            continue;
+        }
+
+        applyArtistBrowseCta(anchor, reference);
+    }
+}
+
+function syncMutationTarget(mutation: MutationRecord): void {
+    if (mutation.target instanceof Element) {
+        syncArtistBrowseCtas(mutation.target);
+        return;
+    }
+
+    if (mutation.target.parentElement instanceof HTMLElement) {
+        syncArtistBrowseCtas(mutation.target.parentElement);
+    }
+}
+
+export function installDeviantArtArtistBrowseCtas(): () => void {
+    if (isInstalled || !isDeviantArtHostname()) {
+        return noop;
+    }
+
+    isInstalled = true;
+    syncArtistBrowseCtas(document);
+
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            if (mutation.type === 'characterData') {
+                syncMutationTarget(mutation);
+                continue;
+            }
+
+            if (mutation.type !== 'childList') {
+                continue;
+            }
+
+            syncMutationTarget(mutation);
+
+            for (const addedNode of mutation.addedNodes) {
+                if (addedNode instanceof Element) {
+                    syncArtistBrowseCtas(addedNode);
+                }
+            }
+        }
+    });
+
+    observer.observe(document.documentElement, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+    });
+
+    return () => {
+        observer.disconnect();
+        isInstalled = false;
+    };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::post('/api/extension/browse-tabs/civitai-model', [\App\Http\Controllers\E
     ->name('api.extension.browse-tabs.civitai-model');
 Route::post('/api/extension/browse-tabs/civitai-user', [\App\Http\Controllers\ExtensionApiController::class, 'openCivitAiUserBrowseTab'])
     ->name('api.extension.browse-tabs.civitai-user');
+Route::post('/api/extension/browse-tabs/deviantart-user', [\App\Http\Controllers\ExtensionApiController::class, 'openDeviantArtUserBrowseTab'])
+    ->name('api.extension.browse-tabs.deviantart-user');
 Route::post('/api/extension/broadcasting/auth', [\App\Http\Controllers\ExtensionApiController::class, 'broadcastAuth'])
     ->name('api.extension.broadcast-auth');
 

--- a/tests/Feature/Extension/ExtensionBrowseTabsTest.php
+++ b/tests/Feature/Extension/ExtensionBrowseTabsTest.php
@@ -184,3 +184,39 @@ it('enables nsfw params for civitai user browse tabs when requested by the exten
     expect($createdTab)->not->toBeNull();
     expect($createdTab?->params['nsfw'] ?? null)->toBeTrue();
 });
+
+it('creates and activates a deviantart browse tab for the requested username filter', function () {
+    $user = User::factory()->create();
+    setExtensionBrowseTabsApiKey('valid-api-key', $user->id);
+
+    $existingActiveTab = Tab::factory()->create([
+        'user_id' => $user->id,
+        'label' => 'Existing Active',
+        'position' => 0,
+        'is_active' => true,
+    ]);
+
+    $response = $this->withHeaders([
+        'X-Atlas-Api-Key' => 'valid-api-key',
+    ])->postJson('/api/extension/browse-tabs/deviantart-user', [
+        'username' => ' velvetemberartist ',
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJsonPath('tab.label', 'DeviantArt Images: User velvetemberartist - 1');
+    $response->assertJsonPath('tab.params.feed', 'online');
+    $response->assertJsonPath('tab.params.service', 'deviantart-images');
+    $response->assertJsonPath('tab.params.username', 'velvetemberartist');
+    $response->assertJsonPath('browse_url', url('/browse'));
+
+    $createdTab = Tab::query()
+        ->where('user_id', $user->id)
+        ->where('label', 'DeviantArt Images: User velvetemberartist - 1')
+        ->first();
+
+    expect($createdTab)->not->toBeNull();
+    expect($createdTab?->position)->toBe(1);
+    expect($createdTab?->is_active)->toBeTrue();
+    expect($existingActiveTab->fresh()?->is_active)->toBeFalse();
+    expect($createdTab?->params['username'] ?? null)->toBe('velvetemberartist');
+});


### PR DESCRIPTION
## Summary
- Add an Atlas extension API endpoint for opening DeviantArt user browse tabs
- Add a DeviantArt browser CTA on profile and deviation pages to open the artist in Atlas
- Add extension-side message handling and tests for the new browse flow

## Testing
- Not run (not requested)
- Added coverage for the background message handler and DeviantArt CTA injection behavior